### PR TITLE
Convert to manifest_version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 In the Chrome Web Store at https://chrome.google.com/webstore/detail/favidenticon-for-google-d/alkonpgilhahbbhihdjnamkmckfajmjo
 
+Gives Docs, Sheets, Slides, Forms, and Drawings unique favicons per document.
+
 ![](icons/screen640.png "")

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,26 @@
 {
-    "manifest_version": 3,
-
-    "name": "FavIdenticon for Google Docs",
-    "version": "1.0.2",
-	"author": "@isaach",
-	"description": "Gives Docs, Sheets, Slides, Forms, and Drawings unique favicons per document.",
-
-	"icons": { "16": "icons/icon16.png",
-	           "48": "icons/icon48.png",
-	          "128": "icons/icon128.png" },
-			  
-    "content_scripts": [
-        {
-          "matches": ["https://docs.google.com/*"],
-          "js": [ "lib/sha1.js", "lib/pnglib.js", "lib/identicon.js", "index.js" ]
-        }
-    ]
-
- }
+  "manifest_version": 3,
+  "name": "FavIdenticon for Google Docs",
+  "version": "1.0.2",
+  "author": "@isaach",
+  "description": "Gives Docs, Sheets, Slides, Forms, and Drawings unique favicons per document.",
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://docs.google.com/*"
+      ],
+      "js": [
+        "lib/sha1.js",
+        "lib/pnglib.js",
+        "lib/identicon.js",
+        "index.js"
+      ]
+    }
+  ],
+  "content_security_policy": {}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
 
     "name": "FavIdenticon for Google Docs",
     "version": "1.0.2",


### PR DESCRIPTION
Manifest version 2 is no longer supported in Chrome Web Store.

Converted using Google's converter Python script:
https://developer.chrome.com/docs/extensions/develop/migrate